### PR TITLE
Local Development

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-build
-build_docker_cross
-*.yaml
-*.yml
+.git
+Dockerfile
+tests/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,35 @@ jobs:
       - name: Run Tests
         run: ./run-tests.sh
         working-directory: ./tests
+
+  test_unit:
+    strategy:
+      matrix:
+        go-version: [1.17.x]
+        platform: [ubuntu-20.04]
+
+    runs-on: ${{ matrix.platform }}
+    steps:
+
+      - name: Install Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Download dependencies
+        run: |
+          go mod download
+          go mod tidy -v
+
+      - name: Test
+        run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+on:
+    push:
+      branches:
+        - '*'
+    pull_request:
+      branches:
+        - '*'
+
+name: Running Tests
+
+jobs:
+  test_integration:
+    strategy:
+      matrix:
+        platform: [ubuntu-20.04]
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Start Localstack
+        run: make localstack
+
+      - name: Create a docker image
+        run: make docker
+
+      - name: Run Tests
+        run: ./run-tests.sh
+        working-directory: ./tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM golang:1.17 as build-dev
+
+WORKDIR /biscuit
+
+COPY go.mod .
+COPY go.sum .
+
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -o ~/biscuit *.go
+
+FROM alpine:3.14.2
+
+COPY --from=build-dev /root/biscuit /usr/local/bin/.
+
+RUN apk update && apk add --no-cache \
+  ca-certificates \
+  bash \
+  openssl
+
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
+USER appuser
+
+ENTRYPOINT ["biscuit"]

--- a/Makefile
+++ b/Makefile
@@ -56,3 +56,7 @@ docker-cross: docker-build
 		"rm -f build && ln -s /tmp/build/ build && make cross"
 
 
+.PHONY: localstack
+localstack:
+	docker network create localstack
+	docker run --name localstack --network localstack --rm -d -p 4566:4566 -p 4571:4571 localstack/localstack:0.12.17.5

--- a/Makefile
+++ b/Makefile
@@ -60,3 +60,7 @@ docker-cross: docker-build
 localstack:
 	docker network create localstack
 	docker run --name localstack --network localstack --rm -d -p 4566:4566 -p 4571:4571 localstack/localstack:0.12.17.5
+
+.PHONY: docker
+docker:
+	docker build -t ghcr.io/dcoker/biscuit .

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ build: doc.go test
 .PHONY: test
 test:
 	$(GO) test $(GOFLAGS) $(PKG)
-	$(GO) test $(GOFLAGS) $(PKG)
 
 doc.go: data
 	/bin/echo -e '/*\n' > doc.go

--- a/commands/awskms/cfhelper.go
+++ b/commands/awskms/cfhelper.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	myAWS "github.com/dcoker/biscuit/internal/aws"
 )
 
 type cloudformationStack struct {
@@ -28,7 +28,7 @@ func (s *cloudformationStack) parameterList() (output []*cloudformation.Paramete
 }
 
 func (s *cloudformationStack) createAndWait() (map[string]string, error) {
-	cfclient := cloudformation.New(session.New(&aws.Config{Region: &s.region}))
+	cfclient := cloudformation.New(myAWS.NewSession(s.region))
 	createStackInput := &cloudformation.CreateStackInput{
 		StackName:    &s.stackName,
 		Capabilities: []*string{aws.String("CAPABILITY_IAM")},

--- a/commands/awskms/kmsdeprovision.go
+++ b/commands/awskms/kmsdeprovision.go
@@ -6,10 +6,9 @@ import (
 	"os"
 	"sync"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/kms"
+	myAWS "github.com/dcoker/biscuit/internal/aws"
 	"github.com/dcoker/biscuit/shared"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
@@ -57,7 +56,7 @@ func (w *kmsDeprovision) deprovisionOneRegion(region string) error {
 	stackName := cfStackName(*w.label)
 	fmt.Printf("%s: Searching for label '%s'...\n", region, *w.label)
 	var foundAlias *kms.AliasListEntry
-	kmsClient := kmsHelper{kms.New(session.New(&aws.Config{Region: &region}))}
+	kmsClient := kmsHelper{kms.New(myAWS.NewSession(region))}
 	foundAlias, err := kmsClient.GetAliasByName(aliasName)
 	if err != nil {
 		return err
@@ -85,7 +84,7 @@ func (w *kmsDeprovision) deprovisionOneRegion(region string) error {
 	}
 	fmt.Printf("%s: Found stack: %s\n", region, stackName)
 	if *w.destructive {
-		cfclient := cloudformation.New(session.New(&aws.Config{Region: &region}))
+		cfclient := cloudformation.New(myAWS.NewSession(region))
 		fmt.Printf("%s: Deleting CloudFormation stack. This may take a while...\n", region)
 		if _, err := cfclient.DeleteStack(&cloudformation.DeleteStackInput{StackName: &stackName}); err != nil {
 			return err

--- a/commands/awskms/kmsid.go
+++ b/commands/awskms/kmsid.go
@@ -3,8 +3,8 @@ package awskms
 import (
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
+	myAWS "github.com/dcoker/biscuit/internal/aws"
 )
 
 // KmsGetCallerIdentity prints AWS client configuration info.
@@ -12,7 +12,7 @@ type KmsGetCallerIdentity struct{}
 
 // Run prints the results of STS GetCallerIdentity.
 func (w *KmsGetCallerIdentity) Run() error {
-	session := session.New()
+	session := myAWS.NewSession("")
 	credentials, err := session.Config.Credentials.Get()
 	if err != nil {
 		return err

--- a/internal/aws/aws.go
+++ b/internal/aws/aws.go
@@ -1,0 +1,27 @@
+package aws
+
+import (
+	"os"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+)
+
+func NewSession(r string) *session.Session {
+	cfg := &aws.Config{}
+	if r != "" {
+		cfg.Region = aws.String(r)
+	}
+
+	endpoint := os.Getenv("AWS_ENDPOINT")
+	if endpoint != "" {
+		cfg.Endpoint = aws.String(endpoint)
+	}
+
+	level := os.Getenv("BISCUIT_DEBUG")
+	if level == "true" {
+		cfg.WithLogLevel(aws.LogDebug)
+	}
+	sess := session.New(cfg)
+	return sess
+}

--- a/keymanager/awskms.go
+++ b/keymanager/awskms.go
@@ -2,8 +2,8 @@ package keymanager
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/kms"
+	myAWS "github.com/dcoker/biscuit/internal/aws"
 )
 
 const (
@@ -68,7 +68,7 @@ func (k *Kms) Label() string {
 func newKmsClient(arn string) (*kms.KMS, error) {
 	parsed, err := NewARN(arn)
 	if err != nil {
-		return kms.New(session.New()), nil
+		return kms.New(myAWS.NewSession("")), nil
 	}
-	return kms.New(session.New(&aws.Config{Region: &parsed.Region})), nil
+	return kms.New(myAWS.NewSession(parsed.Region)), nil
 }

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -57,6 +57,7 @@ for one_test in 0*sh; do
 done
 echo ">> waiting"
 wait
+exitCode=0
 for test_log in "${RESULTS_DIR}"/*.log; do
   echo -n "${test_log}: "
   if grep -q '+++++ PASSED' "${test_log}"; then
@@ -64,5 +65,7 @@ for test_log in "${RESULTS_DIR}"/*.log; do
   else
     echo "FAILED :("
     cat "${test_log}"
+    exitCode=1
   fi
 done
+exit ${exitCode}

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -12,12 +12,14 @@ export AWS_REGION=us-west-1
 export REGION1=us-west-1
 export REGION2=us-west-2
 
+aws --region=${REGION1} kms delete-alias --alias-name alias/biscuit-default 2>/dev/null || echo "No alias exist"
 export AWS_ACCOUNT=$(aws --region=${REGION1} sts get-caller-identity | jq -r '.Account')
 export KEY1=$(aws --region=${REGION1} kms create-key | jq -r '.KeyMetadata.KeyId')
 export ARN1=arn:aws:kms:${REGION1}:${AWS_ACCOUNT}:key/${KEY1}
 aws --region=${REGION1} kms create-alias --alias-name alias/biscuit-default --target-key-id ${ARN1}
 
 
+aws --region=${REGION2} kms delete-alias --alias-name alias/biscuit-default 2>/dev/null || echo "No alias exist"
 export KEY2=$(aws --region=${REGION2} kms create-key | jq -r '.KeyMetadata.KeyId')
 export ARN2=arn:aws:kms:${REGION2}:${AWS_ACCOUNT}:key/${KEY2}
 aws --region=${REGION2} kms create-alias --alias-name alias/biscuit-default --target-key-id ${ARN2}

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -3,45 +3,53 @@
 # Run a bunch of shell-based tests in isolated environments using Docker.
 #
 set -e
-REPOSITORY=/go/src/github.com/dcoker/biscuit/
-if [ "${CONTINUOUS_INTEGRATION}" != "true" ]; then
-  echo __ Running with credentials from biscuit-testing profile.
-  AWS_ACCESS_KEY_ID="$(aws configure --profile biscuit-testing get aws_access_key_id)"
-  AWS_SECRET_ACCESS_KEY="$(aws configure --profile biscuit-testing get aws_secret_access_key)"
-fi
-# Test keys created with `biscuit kms init`.
-# user/cli-integration-test granted usage of keys via `biscuit kms edit-key-policy`.
-AWS_ACCOUNT=872957446280
-AWS_REGION=us-west-1
-KEY1=8be1cc5b-3c70-4295-acad-e497dd421961
-ARN1=arn:aws:kms:us-west-1:${AWS_ACCOUNT}:key/${KEY1}
-ARN1_REGION=us-west-1
-KEY2=37cca9a8-d2d0-43b8-9363-bb8320176cee
-ARN2=arn:aws:kms:us-west-1:${AWS_ACCOUNT}:key/${KEY2}
-ARN2_REGION=us-west-1
+
+function aws() {
+  docker run --network localstack -e AWS_ACCESS_KEY_ID=test -e AWS_SECRET_ACCESS_KEY=test --rm amazon/aws-cli  --endpoint=http://localstack:4566 "$@"
+}
+
+export AWS_REGION=us-west-1
+export REGION1=us-west-1
+export REGION2=us-west-2
+
+export AWS_ACCOUNT=$(aws --region=${REGION1} sts get-caller-identity | jq -r '.Account')
+export KEY1=$(aws --region=${REGION1} kms create-key | jq -r '.KeyMetadata.KeyId')
+export ARN1=arn:aws:kms:${REGION1}:${AWS_ACCOUNT}:key/${KEY1}
+aws --region=${REGION1} kms create-alias --alias-name alias/biscuit-default --target-key-id ${ARN1}
+
+
+export KEY2=$(aws --region=${REGION2} kms create-key | jq -r '.KeyMetadata.KeyId')
+export ARN2=arn:aws:kms:${REGION2}:${AWS_ACCOUNT}:key/${KEY2}
+aws --region=${REGION2} kms create-alias --alias-name alias/biscuit-default --target-key-id ${ARN2}
 
 function invoke_one() {
-  docker run -t \
-    -e AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" \
-    -e AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
-    -e AWS_REGION="${AWS_REGION}" \
-    -e KEY1="${KEY1}" \
-    -e ARN1="${ARN1}" \
-    -e ARN1_REGION="${ARN1_REGION}" \
-    -e KEY2="${KEY2}" \
-    -e ARN2="${ARN2}" \
-    -e ARN2_REGION="${ARN2_REGION}" \
-    -e REPOSITORY=${REPOSITORY} \
-    -w /tmp \
-    biscuit/local \
-    /bin/bash -c "$@"
+  docker run \
+    --network=localstack \
+    -v $(pwd):/tests \
+    -w /home/appuser \
+    -e AWS_ACCESS_KEY_ID=test \
+    -e AWS_SECRET_ACCESS_KEY=test \
+    -e AWS_ENDPOINT=http://localstack:4566 \
+    -e AWS_ACCOUNT=${AWS_ACCOUNT} \
+    -e AWS_REGION=${AWS_REGION} \
+    -e REGION1=${REGION1} \
+    -e ARN1_REGION=${REGION1} \
+    -e KEY1=${KEY1} \
+    -e ARN1=${ARN1} \
+    -e REGION2=${REGION2} \
+    -e ARN2_REGION=${REGION2} \
+    -e KEY2=${KEY2} \
+    -e ARN2=${ARN2} \
+    --entrypoint=/bin/bash \
+    ghcr.io/dcoker/biscuit:latest \
+    -c "$@"
 }
 
 RESULTS_DIR=$(mktemp -d)
 echo ">>>>> Logging to ${RESULTS_DIR}"
 for one_test in 0*sh; do
   echo ">>>>> Running test: ${one_test}"
-  (invoke_one "${REPOSITORY}/tests/${one_test}" && echo "+++++ PASSED" || echo "----- FAILED") \
+  (invoke_one "/tests/${one_test}" && echo "+++++ PASSED" || echo "----- FAILED") \
     > "${RESULTS_DIR}/${one_test}.log" \
     2>&1 &
 done


### PR DESCRIPTION
Update binary to allow custom AWS endpoint

Use `localstack` as a default for testing

Update testing framework to use Github Workflows instead

Following in up on https://github.com/dcoker/biscuit/pull/15, this enables all branches to run tests and allows test to run against [localstack](https://github.com/localstack/localstack) 